### PR TITLE
Closes softlayer/sl-ember-translate#84

### DIFF
--- a/addon/components/sl-translate.js
+++ b/addon/components/sl-translate.js
@@ -80,7 +80,7 @@ export default Ember.Component.extend({
         var parameters         = [],
             observedParameters = [];
 
-        Ember.keys( this ).map( function( key ) {
+        Ember.keys( this ).map( Ember.run.bind( this, function( key ) {
 
             // Is a number that begins with $ but doesn't also end with "Binding"
             if ( /^\$/.test( key ) && !/^\$.*(Binding)$/.test( key ) ) {
@@ -91,7 +91,7 @@ export default Ember.Component.extend({
             if ( /^\$[0-9]*$/.test( key ) && this.hasOwnProperty( key + 'Binding' ) ) {
                 observedParameters.push( key );
             }
-        }.bind( this ));
+        }));
 
         this.setProperties({
             'parameters'         : parameters,
@@ -112,9 +112,9 @@ export default Ember.Component.extend({
      * @returns  {void}
      */
     registerObservers: function() {
-        this.get( 'observedParameters' ).map( function( key ) {
+        this.get( 'observedParameters' ).map( Ember.run.bind( this, function( key ) {
             this.addObserver( key, this, this.setTranslatedString );
-        }.bind( this ));
+        }));
 
         this.setTranslatedString();
     }.on( 'willInsertElement' ),
@@ -127,9 +127,9 @@ export default Ember.Component.extend({
      * @returns  {void}
      */
     unregisterObservers: function() {
-        this.get( 'observedParameters' ).map( function( key ) {
+        this.get( 'observedParameters' ).map( Ember.run.bind( this, function( key ) {
             this.removeObserver( key, this, this.setTranslatedString );
-        }.bind( this ));
+        }));
     }.on( 'willClearRender' ),
 
     // -------------------------------------------------------------------------
@@ -158,9 +158,9 @@ export default Ember.Component.extend({
     translateString: function() {
         var parametersHash = {};
 
-        this.get( 'parameters' ).map( function( key ) {
+        this.get( 'parameters' ).map( Ember.run.bind( this, function( key ) {
             parametersHash[key] = this.get( key );
-        }.bind( this ));
+        }));
 
         return this.get( 'translateService' ).translateKey({
             key         : this.get( 'key' ),

--- a/addon/services/translate.js
+++ b/addon/services/translate.js
@@ -102,7 +102,7 @@ export default Ember.Object.extend({
 
         var pluralErrorTracker = 0,
             token              = data.key,
-            getTokenValue      = function( value ) {
+            getTokenValue      = Ember.run.bind( this, function( value ) {
                 try {
                     value = this.getKeyValue( value );
                 } catch ( e ) {
@@ -110,7 +110,7 @@ export default Ember.Object.extend({
                 }
 
                 return value;
-            }.bind( this ),
+            }),
             translatedString;
 
         // BEGIN: Pluralization error checking
@@ -139,7 +139,7 @@ export default Ember.Object.extend({
         // Parameter replacement
         Ember.keys( data.parameters ).map( function( key ) {
             translatedString = translatedString.replace( '{' + key.replace( '$', '' ) + '}' , data.parameters[key] );
-        }.bind( this ) );
+        });
 
         return translatedString;
     }

--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,6 @@
     "ember-load-initializers": "stefanpenner/ember-load-initializers#0.0.2",
     "ember-qunit": "0.1.8",
     "ember-qunit-notifications": "0.0.4",
-    "qunit": "~1.15.0",
-    "es5-shim": "^4.0.5"
+    "qunit": "~1.15.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "broccoli-string-replace": "0.0.2",
     "ember-cli": "0.1.5",
     "ember-cli-dependency-checker": "0.0.7",
-    "ember-cli-es5-shim": "~0.1.0",
     "ember-cli-esnext": "0.1.1",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",


### PR DESCRIPTION
Replaced .bind() calls with Ember.run.bind() to adapt to removal of shim